### PR TITLE
np.int changed to int

### DIFF
--- a/MemGuard/input_data_class.py
+++ b/MemGuard/input_data_class.py
@@ -71,7 +71,7 @@ class InputData():
         y_train_defender=np.concatenate((y_train_user,y_nontrain_defender),axis=0)
         y_train_defender=y_train_defender-1.0
 
-        label_train_defender=np.zeros([x_train_defender.shape[0]],dtype=np.int)
+        label_train_defender=np.zeros([x_train_defender.shape[0]],dtype=int)
         label_train_defender[0:x_train_user.shape[0]]=1
         return (x_train_defender,y_train_defender,label_train_defender)
 
@@ -90,7 +90,7 @@ class InputData():
         x_train_attacker=np.concatenate((x_train_member_attacker,x_train_nonmember_attacker),axis=0)
         y_train_attacker=np.concatenate((y_train_member_attacker,y_train_nonmumber_attacker),axis=0)
         y_train_attacker=y_train_attacker-1.0
-        label_train_attacker=np.zeros([x_train_attacker.shape[0]],dtype=np.int)
+        label_train_attacker=np.zeros([x_train_attacker.shape[0]],dtype=int)
         label_train_attacker[0:x_train_member_attacker.shape[0]]=1
 
         return (x_train_attacker,y_train_attacker,label_train_attacker)
@@ -111,7 +111,8 @@ class InputData():
         x_evaluate_attacker=np.concatenate((x_evaluate_member_attacker,x_evaluate_nonmember_attacker),axis=0)
         y_evaluate_attacker=np.concatenate((y_evaluate_member_attacker,y_evaluate_nonmumber_attacker),axis=0)
         y_evaluate_attacker=y_evaluate_attacker-1.0
-        label_evaluate_attacker=np.zeros([x_evaluate_attacker.shape[0]],dtype=np.int)
+        #Change int to int, `int` was a deprecated alias for the builtin `int`. To avoid this error in existing code, use `int` by itself
+        label_evaluate_attacker=np.zeros([x_evaluate_attacker.shape[0]],dtype=int)
         label_evaluate_attacker[0:x_evaluate_member_attacker.shape[0]]=1
 
         return (x_evaluate_attacker,y_evaluate_attacker,label_evaluate_attacker)


### PR DESCRIPTION
numpy.int was [deprecated in [NumPy 1.20](https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations)] and was [removed in NumPy 1.24](https://numpy.org/devdocs/release/1.24.0-notes.html#expired-deprecations).